### PR TITLE
[Multiple Guilds] Add the ability to target multiple guilds on a per-configuration basis

### DIFF
--- a/lib/bot/__init__.py
+++ b/lib/bot/__init__.py
@@ -1,4 +1,5 @@
 import os
+import json
 from glob import glob
 from asyncio import sleep
 import json
@@ -99,13 +100,17 @@ class Bot(BotBase):
                 self.GUILD = int(gf.read())
 
             self.guild = self.get_guild(self.GUILD)
-
+            
             with open("./lib/bot/channel.0", "r", encoding = "utf-8") as cf:
                 self.CHANNEL = int(cf.read())
-            
-            self.stdout = self.get_channel(self.CHANNEL)
-            self.stdlog = self.get_channel(798723281909186590)
 
+            with open("./lib/db/guilds.json", "r", encoding = "utf-8") as guilds:
+                self.guild_config = json.load(guilds)
+                print(self.guild_config)
+
+            self.stdout = self.get_channel(self.CHANNEL)
+            self.stdlog = self.get_channel(self.CHANNEL)
+            
             while not self.cogs_ready.all_ready():
                 await sleep(0.5)
 
@@ -116,10 +121,53 @@ class Bot(BotBase):
             print("Status: Reconnected")
 
     async def on_message(self, message):
-        with open('./lib/bot/server_deployments.json','r') as f:
-            deployed = json.load(f)
+        if not message.author.bot:
+            await self.process_commands(message)
 
-            if not message.author.bot:
-                await self.process_commands(message)
     
+    def get_response_channel(self, ctx):
+        """
+            This function will look in the guild configuration to find an appropriate response channel.
+            If no channel can be located, an error is thrown
+        """
+        print("Looking for response channel")
+        print(self.guild_config)
+        guild_id = f"{ctx.message.guild.id}"
+
+        if guild_id in self.guild_config:
+            print("guild exists in config")
+            # check the channel policy to see what happens by default with channel traffic
+            print(self.guild_config[guild_id]['channel_policy']['default'])
+            if self.guild_config[guild_id]['channel_policy']['default'] == "allow":
+                print("Channel policy is allow")
+                # if the channel is in the list, it is on a blacklist for either listen or respond. ignore it
+                if f"{ctx.message.channel.id}" in self.guild_config[guild_id]['channel_policy']['channels']:
+                    return None
+                else:
+                    return ctx.message.channel
+            else:
+                return None
+        else:
+            # create a new guild entry
+            print(f"Writing new guild entry for non-existant guild {ctx.message.guild.name} ({ctx.message.guild.id})")
+            self.guild_config[guild_id] = self.create_guild_entry(ctx.message.guild.name)
+            # write the json config back, then reload the guild config
+            with open("./lib/db/guilds.json", "w") as config:
+                json.dump(self.guild_config, config)
+            
+            with open("./lib/db/guilds.json", "r", encoding="utf-8") as config:
+                self.guild_config = json.load(config)
+
+            print(f"New guild configuration: {self.guild_config}")
+            return self.get_response_channel(ctx)
+
+    def create_guild_entry(self,guild_name):
+        return {
+            "alias": guild_name,
+            "channel_policy": {
+                "default": "allow",
+                "channels": {}
+            }
+        }
+
 bot = Bot()

--- a/lib/cogs/admin.py
+++ b/lib/cogs/admin.py
@@ -1,0 +1,12 @@
+import json
+
+from discord import Member
+from discord.ext.commands import Cog
+from discord.ext.commands import command
+from discord import Intents, Embed, File
+
+class Admin(Cog):
+    def __init__(self,bot):
+        self.bot = bot
+
+    

--- a/lib/cogs/hunt.py
+++ b/lib/cogs/hunt.py
@@ -78,6 +78,7 @@ class Hunt(Cog):
         self.bot = bot
 
     async def get_stats(self,ctx,user_hunt,user_stat,embed):
+        
         if user_stat=="all":
             for key in general_stats:
                 stat_data = hunt_array[user_hunt][0][key]
@@ -85,7 +86,7 @@ class Hunt(Cog):
                 embed.add_field(name=general_stats[key][0], value="\n".join(i for i in stat_data), inline=general_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
 
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
             embed.clear_fields()
 
             for key in score_stats:
@@ -94,7 +95,7 @@ class Hunt(Cog):
                 embed.add_field(name=score_stats[key][0], value="\n".join(i for i in stat_data), inline=score_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
             embed.clear_fields()
             
             for key in need_stats:
@@ -103,7 +104,7 @@ class Hunt(Cog):
                 embed.add_field(name=need_stats[key][0], value="\n".join(i for i in stat_data), inline=need_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
             embed.clear_fields()
         
             for key in equipment_stats:
@@ -112,7 +113,7 @@ class Hunt(Cog):
                 embed.add_field(name=equipment_stats[key][0], value="\n".join(i for i in stat_data), inline=equipment_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
             embed.clear_fields()
 
         elif user_stat=="general":
@@ -122,7 +123,7 @@ class Hunt(Cog):
                 embed.add_field(name=general_stats[key][0], value="\n".join(i for i in stat_data), inline=general_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
 
         elif user_stat=="score" or user_stat=="scores":
             for key in score_stats:
@@ -131,7 +132,7 @@ class Hunt(Cog):
                 embed.add_field(name=score_stats[key][0], value="\n".join(i for i in stat_data), inline=score_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
 
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
 
         elif user_stat=="need" or user_stat=="needs" or user_stat=="zone" or user_stat=="zones":
             for key in need_stats:
@@ -140,7 +141,7 @@ class Hunt(Cog):
                 embed.add_field(name=need_stats[key][0], value="\n".join(i for i in stat_data), inline=need_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
 
         elif user_stat=="equipment" or user_stat=="item" or user_stat=="items":
             for key in equipment_stats:
@@ -149,7 +150,7 @@ class Hunt(Cog):
                 embed.add_field(name=equipment_stats[key][0], value="\n".join(i for i in stat_data), inline=equipment_stats[key][1])
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx,embed=embed)
 
         else:
             stat_data = hunt_array[user_hunt][0][user_stat]
@@ -157,7 +158,15 @@ class Hunt(Cog):
             embed.add_field(name=stat_description[user_stat], value="\n".join(i for i in stat_data), inline=True)
             embed.set_footer(text=f"{ctx.author.display_name}; {dt_formatted}")
             
-            await self.bot.stdout.send(embed=embed)
+            await self.send_embed(ctx=ctx, embed=embed)
+
+    async def send_embed(self,ctx,embed):
+        channel = self.bot.get_response_channel(ctx)
+        print("Trying to send embed to channel")
+        if channel is not None:
+            await channel.send(embed=embed)
+        else:
+            print("Message send denied (no channel available)")
 
     @command(name="mallard",aliases=["mallards"])
     async def get_mallard(self,ctx,*,stat):

--- a/lib/db/guilds.json
+++ b/lib/db/guilds.json
@@ -1,0 +1,1 @@
+{"775725364575862794": {"alias": "testserver_beegul", "channel_policy": {"default": "allow", "channels": {"775725364575862798": {"listen": "deny", "respond": "deny"}}}}, "801549846359310347": {"alias": "testserver_beegul_2", "channel_policy": {"default": "allow", "channels": {}}}}


### PR DESCRIPTION
This branch is still a work in progress; please don't merge it at this point. I added code to read guild-specific configuration options from a config file and updated hunt.py to use the new configuration. The code will also create a new default configuration whenever a new guild appears and starts using the bot. This code needs refactored before it can be merged, and I also need to make sure I eliminate all the calls to write to the stdlog channel (this needs to be added as a configuration option in the guild config).

## Must dos:

- Create administrative command cog that allows specific users and roles to be added as allowed admin users
- Add administrative commands to blacklist or whitelist specific channels
- Add administrative commands to set log channel for guild
- Add code to handle the default: deny case for the guild channels policy

## Would be nice if:

- We possibly could provide a new folder under the db folder called "guilds", and added a single json file per guild, rather than rewriting the entire guild file every time a new guild is added
- Refactor all the message sending code to go through the bot rather than in the individual cogs

If there are any other suggestions for this effort, just add them as comments to this pull request and I can try to address them.